### PR TITLE
React UI refactor: unified thread + controllers, interaction layer, and views

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.6.9
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ['--fix']
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -13,4 +13,3 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
         args: ['--branch', 'main']
-

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ cp .env.example .env
 Configure the API endpoint in your environment file:
 
 ```env
-VITE_API_URL=http://localhost:8000  # Celeste API URL
-VITE_WS_URL=ws://localhost:8000     # WebSocket URL for streaming
+VITE_API_BASE_URL=http://localhost:8000  # Celeste API base URL
+VITE_WS_URL=ws://localhost:8000          # WebSocket URL for streaming
 ```
 
 ## ✨ Features
@@ -272,6 +272,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 <div align="center">
   Made with ❤️ by the Celeste Team
-  
-  <a href="#️-celeste-react">⬆ Back to Top</a>
+
+<a href="#️-celeste-react">⬆ Back to Top</a>
+
 </div>

--- a/src/components/controls/ModelSelect.tsx
+++ b/src/components/controls/ModelSelect.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useUiStore } from '../../lib/store/ui';
 import styles from './ProviderSelect.module.css';
-import type { ModelOut } from '../../hooks/useModels';
+import { useSelectionsStore } from '../../lib/store/selections';
+import type { ModelOut } from '../../types/api';
 
 export function ModelSelect({
   models,
@@ -76,6 +77,8 @@ export function ModelSelect({
               className={styles.item}
               onClick={() => {
                 onChange(m.id);
+                // If provider is All providers, set it to model's provider for execution readiness
+                useSelectionsStore.getState().selectModelFromCatalog(m as any);
                 setOpen(false);
               }}
             >

--- a/src/components/input/InputBar.tsx
+++ b/src/components/input/InputBar.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-// import IconButton from '../common/IconButton';
-import styles from './ChatInput.module.css';
+import styles from '../chat/ChatInput.module.css';
 import { ProviderSelect } from '../controls/ProviderSelect';
 import { ModelSelect } from '../controls/ModelSelect';
-import CapabilityButtons from './CapabilityButtons';
-import type { ModelOut } from '../../types/api';
-import type { ProviderOut } from '../../types/api';
+import CapabilityButtons from '../chat/CapabilityButtons';
+import type { ModelOut, ProviderOut } from '../../types/api';
 
-type ChatInputProps = {
+type Props = {
   inputValue: string;
   onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  onSend: () => void;
-  onRefresh: () => void; // currently unused, reserved for future actions
+  onSend: (prompt: string) => void;
+  onRefresh: () => void;
   selectedModel: string;
   onChangeModel: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   models?: ModelOut[];
@@ -27,7 +25,7 @@ type ChatInputProps = {
   showVideo?: boolean;
 };
 
-function ChatInput({
+export default function InputBar({
   inputValue,
   onInputChange,
   onKeyPress,
@@ -46,7 +44,13 @@ function ChatInput({
   showText = true,
   showImage = true,
   showVideo = true,
-}: ChatInputProps) {
+}: Props) {
+  const placeholder =
+    selectedCapability === 'image'
+      ? "Décrivez l'image à générer…"
+      : selectedCapability === 'video'
+        ? 'Décrivez la vidéo à générer…'
+        : 'Comment puis-je vous aider ?';
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>
@@ -54,7 +58,7 @@ function ChatInput({
           <input
             type="text"
             className={styles.textInput}
-            placeholder="Comment puis-je vous aider ?"
+            placeholder={placeholder}
             value={inputValue}
             onChange={onInputChange}
             onKeyPress={onKeyPress}
@@ -88,7 +92,12 @@ function ChatInput({
               }
               isLoading={isLoadingModels}
             />
-            <button className={styles.sendBtn} onClick={onSend} title="Send message" type="button">
+            <button
+              className={styles.sendBtn}
+              onClick={() => onSend(inputValue)}
+              title="Send message"
+              type="button"
+            >
               ↑
             </button>
           </div>
@@ -97,5 +106,3 @@ function ChatInput({
     </div>
   );
 }
-
-export default ChatInput;

--- a/src/components/results/ResultSurface.module.css
+++ b/src/components/results/ResultSurface.module.css
@@ -1,0 +1,10 @@
+.container {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-6) 120px;
+}
+
+.bottomSpacer {
+  height: 80px;
+}

--- a/src/components/results/ResultSurface.tsx
+++ b/src/components/results/ResultSurface.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Greeting from '../chat/Greeting';
+import { useThreadStore } from '../../stores/thread';
+import ThreadItemView from './ThreadItemView';
+import styles from './ResultSurface.module.css';
+import itemStyles from './ThreadItemView.module.css';
+import { useExecStore } from '../../stores/exec';
+
+export default function ResultSurface() {
+  const items = useThreadStore((s) => s.items);
+  const isGenerating = useExecStore((s) => s.isGenerating);
+
+  return (
+    <div className={styles.container}>
+      {!items || items.length === 0 ? (
+        <Greeting name="Kamil" />
+      ) : (
+        items.map((it) => <ThreadItemView key={it.id} item={it} />)
+      )}
+      {isGenerating && (
+        <div className={`${itemStyles.item} ${itemStyles.assistant}`} aria-live="polite">
+          <div className={itemStyles.avatar} aria-hidden>
+            <span className={itemStyles.spin}>✴</span>
+          </div>
+          <div className={itemStyles.card}>
+            <div className={itemStyles.text}> </div>
+          </div>
+        </div>
+      )}
+      <div className={styles.bottomSpacer} />
+    </div>
+  );
+}

--- a/src/components/results/ThreadItemView.module.css
+++ b/src/components/results/ThreadItemView.module.css
@@ -1,0 +1,58 @@
+.item {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.user {
+  justify-content: flex-end;
+}
+
+.assistant {
+  justify-content: flex-start;
+}
+
+.avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.06);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 28px;
+  color: var(--color-star);
+}
+
+.spin {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.card {
+  max-width: 70ch;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  border-radius: 14px;
+  padding: 12px 14px;
+}
+
+.text {
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.userCard {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.1);
+}

--- a/src/components/results/ThreadItemView.tsx
+++ b/src/components/results/ThreadItemView.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styles from './ThreadItemView.module.css';
+import TextPart from './parts/TextPart';
+import ImagePart from './parts/ImagePart';
+import VideoPart from './parts/VideoPart';
+import type { ContentPart, ThreadItem } from '../../domain/thread';
+
+function PartView({ part }: { part: ContentPart }) {
+  if (part.kind === 'text') {
+    return <TextPart content={part.content} />;
+  }
+  if (part.kind === 'image') {
+    return <ImagePart dataUrl={part.dataUrl} path={part.path} />;
+  }
+  if (part.kind === 'video') {
+    return <VideoPart url={part.url} path={part.path} />;
+  }
+  return null;
+}
+
+export default function ThreadItemView({ item }: { item: ThreadItem }) {
+  const sideClass = item.role === 'user' ? styles.user : styles.assistant;
+  const cardClass = item.role === 'user' ? `${styles.card} ${styles.userCard}` : styles.card;
+  const showAvatar = item.role !== 'user';
+  return (
+    <div className={`${styles.item} ${sideClass}`}>
+      {showAvatar && (
+        <div className={styles.avatar} aria-hidden>
+          <span>✴</span>
+        </div>
+      )}
+      <div className={cardClass}>
+        <div className={styles.text}>
+          {item.parts.map((p, idx) => (
+            <div key={idx}>
+              <PartView part={p} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/results/parts/ImagePart.tsx
+++ b/src/components/results/parts/ImagePart.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ImagePart({ dataUrl, path }: { dataUrl?: string; path?: string }) {
+  if (dataUrl) {
+    return <img src={dataUrl} alt="generated" style={{ maxWidth: '100%' }} />;
+  }
+  if (path) {
+    return (
+      <a href={path} target="_blank" rel="noreferrer">
+        View image
+      </a>
+    );
+  }
+  return <div>Image</div>;
+}

--- a/src/components/results/parts/TextPart.tsx
+++ b/src/components/results/parts/TextPart.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export default function TextPart({ content }: { content: string }) {
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
+}

--- a/src/components/results/parts/VideoPart.tsx
+++ b/src/components/results/parts/VideoPart.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function VideoPart({ url, path }: { url?: string; path?: string }) {
+  const src = url || path;
+  return src ? <video src={src} controls style={{ maxWidth: '100%' }} /> : <div>Video</div>;
+}

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from 'react';
+import { useSelectionsStore } from '../lib/store/selections';
+import { useThreadStore } from '../stores/thread';
+import { useExecStore } from '../stores/exec';
+import { generateImages } from '../services/images';
+
+export function useImageController() {
+  const provider = useSelectionsStore((s) => s.provider) || '';
+  const model = useSelectionsStore((s) => s.model) || '';
+  const addItem = useThreadStore((s) => s.addItem);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const setGlobalGenerating = useExecStore((s) => s.setIsGenerating);
+
+  const execute = useCallback(
+    async (prompt: string) => {
+      const trimmed = prompt.trim();
+      if (!trimmed || !provider || !model) {
+        return;
+      }
+
+      // Append user prompt as a turn
+      addItem({
+        role: 'user',
+        capability: 'image',
+        provider,
+        model,
+        parts: [{ kind: 'text', content: trimmed }],
+      });
+
+      setIsGenerating(true);
+      setGlobalGenerating(true);
+      try {
+        const res = await generateImages({ provider, model, prompt: trimmed });
+        const images = (res?.images || []).map((img: any) => {
+          let dataUrl: string | undefined;
+          if (img?.data) {
+            try {
+              dataUrl = String(img.data).startsWith('data:')
+                ? String(img.data)
+                : `data:image/png;base64,${btoa(String(img.data))}`;
+            } catch {
+              dataUrl = undefined;
+            }
+          }
+          return {
+            kind: 'image' as const,
+            dataUrl,
+            path: img?.path ?? undefined,
+            metadata: img?.metadata ?? {},
+          };
+        });
+
+        // Append assistant images as a turn
+        addItem({
+          role: 'assistant',
+          capability: 'image',
+          provider,
+          model,
+          parts: images,
+        });
+      } finally {
+        setIsGenerating(false);
+        setGlobalGenerating(false);
+      }
+    },
+    [addItem, model, provider],
+  );
+
+  return { execute, isGenerating };
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,3 @@
+export * from './textController';
+export * from './imageController';
+export * from './videoController';

--- a/src/controllers/interaction.ts
+++ b/src/controllers/interaction.ts
@@ -1,0 +1,33 @@
+import { useCallback, useMemo } from 'react';
+import { useSelectionsStore } from '../lib/store/selections';
+import { useTextController } from './textController';
+import { useImageController } from './imageController';
+import { useVideoController } from './videoController';
+
+export function useInteraction() {
+  const capability = useSelectionsStore((s) => s.capability);
+
+  const text = useTextController();
+  const image = useImageController();
+  const video = useVideoController();
+
+  const submit = useCallback(
+    (prompt: string) => {
+      if (capability === 'text') {
+        return text.execute(prompt);
+      }
+      if (capability === 'image') {
+        return image.execute(prompt);
+      }
+      return video.execute(prompt);
+    },
+    [capability, image, text, video],
+  );
+
+  const isGenerating = useMemo(
+    () => text.isGenerating || image.isGenerating || video.isGenerating,
+    [image.isGenerating, text.isGenerating, video.isGenerating],
+  );
+
+  return { submit, isGenerating };
+}

--- a/src/controllers/textController.ts
+++ b/src/controllers/textController.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from 'react';
+import { useSelectionsStore } from '../lib/store/selections';
+import { useThreadStore } from '../stores/thread';
+import { useExecStore } from '../stores/exec';
+import { generateText } from '../services/text';
+
+export function useTextController() {
+  const provider = useSelectionsStore((s) => s.provider) || '';
+  const model = useSelectionsStore((s) => s.model) || '';
+  const addItem = useThreadStore((s) => s.addItem);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const setGlobalGenerating = useExecStore((s) => s.setIsGenerating);
+
+  const execute = useCallback(
+    async (prompt: string) => {
+      const trimmed = prompt.trim();
+      if (!trimmed || !provider || !model) {
+        return;
+      }
+
+      addItem({
+        role: 'user',
+        capability: 'text',
+        provider,
+        model,
+        parts: [{ kind: 'text', content: trimmed }],
+      });
+
+      setIsGenerating(true);
+      setGlobalGenerating(true);
+      try {
+        const res = await generateText({ provider, model, prompt: trimmed });
+        addItem({
+          role: 'assistant',
+          capability: 'text',
+          provider,
+          model,
+          parts: [{ kind: 'text', content: String(res?.content ?? '') }],
+        });
+      } finally {
+        setIsGenerating(false);
+        setGlobalGenerating(false);
+      }
+    },
+    [addItem, model, provider],
+  );
+
+  return { execute, isGenerating };
+}

--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+import { useSelectionsStore } from '../lib/store/selections';
+import { useThreadStore } from '../stores/thread';
+import { useExecStore } from '../stores/exec';
+import { generateVideo } from '../services/video';
+
+export function useVideoController() {
+  const provider = useSelectionsStore((s) => s.provider) || '';
+  const model = useSelectionsStore((s) => s.model) || '';
+  const addItem = useThreadStore((s) => s.addItem);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const setGlobalGenerating = useExecStore((s) => s.setIsGenerating);
+
+  const execute = useCallback(
+    async (prompt: string) => {
+      const trimmed = prompt.trim();
+      if (!trimmed || !provider || !model) {
+        return;
+      }
+
+      // Append user prompt as a turn
+      addItem({
+        role: 'user',
+        capability: 'video',
+        provider,
+        model,
+        parts: [{ kind: 'text', content: trimmed }],
+      });
+
+      setIsGenerating(true);
+      setGlobalGenerating(true);
+      try {
+        const res: any = await generateVideo({ provider, model, prompt: trimmed });
+        const videos = Array.isArray(res?.videos) ? res.videos : [];
+        const parts = videos.map((v: any) => ({
+          kind: 'video' as const,
+          url: v?.url ?? undefined,
+          path: v?.path ?? undefined,
+          metadata: v?.metadata ?? {},
+        }));
+
+        if (parts.length > 0) {
+          addItem({
+            role: 'assistant',
+            capability: 'video',
+            provider,
+            model,
+            parts,
+          });
+        }
+      } finally {
+        setIsGenerating(false);
+        setGlobalGenerating(false);
+      }
+    },
+    [addItem, model, provider],
+  );
+
+  return { execute, isGenerating };
+}

--- a/src/domain/thread.ts
+++ b/src/domain/thread.ts
@@ -1,0 +1,39 @@
+import type { CapabilityId } from '../lib/store/selections';
+
+export type Role = 'user' | 'assistant' | 'system';
+
+export type TextPart = {
+  kind: 'text';
+  content: string;
+};
+
+export type ImagePart = {
+  kind: 'image';
+  dataUrl?: string;
+  path?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type VideoPart = {
+  kind: 'video';
+  url?: string;
+  path?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ContentPart = TextPart | ImagePart | VideoPart;
+
+export interface ThreadItem {
+  id: string;
+  role: Role;
+  capability: CapabilityId;
+  provider: string;
+  model: string;
+  createdAt: number;
+  parts: ContentPart[];
+}
+
+export type ThreadItemInput = Omit<ThreadItem, 'id' | 'createdAt'> & {
+  id?: string;
+  createdAt?: number;
+};

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,6 +1,8 @@
 import React, { useCallback, useState } from 'react';
-import { generateText, listModels } from '../services/api';
+import { generateText } from '../services/text';
+import { generateImages } from '../services/images';
 import { useSelectionsStore } from '../lib/store/selections';
+import { useSelectionsStore as useSel } from '../lib/store/selections';
 
 export type ChatRole = 'user' | 'assistant' | 'system';
 
@@ -16,6 +18,7 @@ export function useChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const provider = useSelectionsStore((s) => s.provider) || '';
   const modelFromStore = useSelectionsStore((s) => s.model) || '';
+  const capability = useSel((s) => s.capability);
   const [isGenerating, setIsGenerating] = useState(false);
 
   const handleSend = useCallback(async () => {
@@ -23,64 +26,63 @@ export function useChat() {
     if (!prompt) {
       return;
     }
-    const userMsg: ChatMessage = {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      role: 'user',
-      content: prompt,
-      createdAt: Date.now(),
-    };
-    setMessages((prev) => [...prev, userMsg]);
-    setInputValue('');
-
-    let providerId = provider;
-    const modelId = modelFromStore;
-
-    // If provider is not selected (All providers), infer provider from selected model
-    if (!providerId && modelId) {
-      try {
-        const all = await listModels();
-        const match = all.find((m: any) => m.id === modelId);
-        if (match) {
-          providerId = match.provider;
-        }
-      } catch {
-        // ignore; will fall back to error message below if still missing
-      }
+    if (capability === 'text') {
+      const userMsg: ChatMessage = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        role: 'user',
+        content: prompt,
+        createdAt: Date.now(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      setInputValue('');
     }
+
+    const providerId = provider;
+    const modelId = modelFromStore;
 
     if (!providerId || !modelId) {
       const errorMsg: ChatMessage = {
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         role: 'assistant',
-        content: "Veuillez sélectionner un fournisseur et un modèle texte avant d'envoyer.",
+        content:
+          capability === 'text'
+            ? "Veuillez sélectionner un fournisseur et un modèle texte avant d'envoyer."
+            : "Veuillez sélectionner un fournisseur et un modèle avant de générer.",
         createdAt: Date.now(),
       };
-      setMessages((prev) => [...prev, errorMsg]);
+      if (capability === 'text') setMessages((prev) => [...prev, errorMsg]);
       return;
     }
-    // Fire-and-forget; append assistant reply when resolved
     setIsGenerating(true);
-    generateText({ provider: providerId, model: modelId, prompt })
-      .then((data) => {
-        const assistantMsg: ChatMessage = {
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          role: 'assistant',
-          content: String(data?.content ?? ''),
-          createdAt: Date.now(),
-        };
-        setMessages((prev) => [...prev, assistantMsg]);
-      })
-      .catch((err) => {
-        const errorMsg: ChatMessage = {
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          role: 'assistant',
-          content: `Erreur: ${err?.message || 'generation failed'}`,
-          createdAt: Date.now(),
-        };
-        setMessages((prev) => [...prev, errorMsg]);
-      })
-      .finally(() => setIsGenerating(false));
-  }, [inputValue, modelFromStore, provider]);
+    if (capability === 'text') {
+      generateText({ provider: providerId, model: modelId, prompt })
+        .then((data) => {
+          const assistantMsg: ChatMessage = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            role: 'assistant',
+            content: String(data?.content ?? ''),
+            createdAt: Date.now(),
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+        })
+        .catch((err) => {
+          const errorMsg: ChatMessage = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            role: 'assistant',
+            content: `Erreur: ${err?.message || 'generation failed'}`,
+            createdAt: Date.now(),
+          };
+          setMessages((prev) => [...prev, errorMsg]);
+        })
+        .finally(() => setIsGenerating(false));
+    } else if (capability === 'image') {
+      generateImages({ provider: providerId, model: modelId, prompt })
+        .finally(() => setIsGenerating(false));
+    } else {
+      // video - placeholder
+      setIsGenerating(false);
+    }
+  }, [capability, inputValue, modelFromStore, provider]);
 
   const handleKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/hooks/useModels.ts
+++ b/src/hooks/useModels.ts
@@ -1,17 +1,6 @@
 import { useEffect, useState } from 'react';
-import { listModels } from '../services/api';
-
-export type ModelOut = {
-  id: string;
-  provider: string;
-  display_name?: string | null;
-  capabilities: string[];
-};
-
-export type ModelFilters = {
-  capability?: string;
-  provider?: string;
-};
+import { listModels } from '../services/discovery';
+import type { ModelOut, ModelFilters } from '../types/api';
 
 export function useModels(filters: ModelFilters = {}) {
   const [models, setModels] = useState<ModelOut[]>([]);

--- a/src/lib/capability.ts
+++ b/src/lib/capability.ts
@@ -1,0 +1,5 @@
+export const capabilityFilterMap: Record<'text' | 'image' | 'video', string> = {
+  text: 'text_generation',
+  image: 'image_generation',
+  video: 'video_generation',
+};

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -1,0 +1,3 @@
+export function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/lib/queries/discovery.ts
+++ b/src/lib/queries/discovery.ts
@@ -1,5 +1,5 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { getHealth, listCapabilities, listProviders, listModels } from '../../services/api';
+import { getHealth, listCapabilities, listProviders, listModels } from '../../services/discovery';
 import type { ModelFilters } from '../../types/api';
 
 // Query keys factory for better organization

--- a/src/lib/store/selections.ts
+++ b/src/lib/store/selections.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { ModelOut } from '../../types/api';
 
 export type CapabilityId = 'text' | 'image' | 'video';
 
@@ -11,6 +12,7 @@ export interface SelectionsState {
   setProvider: (prov: string | null) => void;
   setModel: (model: string | null) => void;
   setStreaming: (enabled: boolean) => void;
+  selectModelFromCatalog: (model: ModelOut) => void;
 }
 
 const STORAGE_KEY = 'celeste_selections_v1';
@@ -62,6 +64,15 @@ export const useSelectionsStore = create<SelectionsState>((set, get) => ({
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({ capability, provider, model, streaming: enabled }),
+    );
+  },
+  selectModelFromCatalog: (modelObj) => {
+    const { capability, provider, streaming } = get();
+    const nextProvider = provider ?? modelObj.provider;
+    set({ model: modelObj.id, provider: nextProvider });
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ capability, provider: nextProvider, model: modelObj.id, streaming }),
     );
   },
 }));

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -1,0 +1,17 @@
+// Centralized API configuration and helpers
+
+export const API_BASE_URL: string = (() => {
+  const url = import.meta.env.VITE_API_BASE_URL as string | undefined;
+  if (!url) {
+    throw new Error('VITE_API_BASE_URL is not set');
+  }
+  return url;
+})();
+
+export async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await response.text().catch(() => 'Unknown error');
+    throw new Error(error || `HTTP ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/src/services/discovery.ts
+++ b/src/services/discovery.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL, handleResponse } from './base';
 import type {
   CapabilityOut,
   ProviderOut,
@@ -6,43 +7,21 @@ import type {
   ModelFilters,
 } from '../types/api';
 
-// Vite environment variable (required)
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-
-if (!API_BASE_URL) {
-  throw new Error('VITE_API_BASE_URL is not set');
-}
-
-export { API_BASE_URL };
-
-// Helper function for handling API errors
-async function handleResponse<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    const error = await response.text().catch(() => 'Unknown error');
-    throw new Error(error || `HTTP ${response.status}: ${response.statusText}`);
-  }
-  return response.json();
-}
-
-// Health check
 export async function getHealth(): Promise<HealthResponse> {
   const res = await fetch(`${API_BASE_URL}/v1/health`);
   return handleResponse<HealthResponse>(res);
 }
 
-// List all capabilities
 export async function listCapabilities(): Promise<CapabilityOut[]> {
   const res = await fetch(`${API_BASE_URL}/v1/capabilities`);
   return handleResponse<CapabilityOut[]>(res);
 }
 
-// List all providers
 export async function listProviders(): Promise<ProviderOut[]> {
   const res = await fetch(`${API_BASE_URL}/v1/providers`);
   return handleResponse<ProviderOut[]>(res);
 }
 
-// List models with optional filters
 export async function listModels(filters: ModelFilters = {}): Promise<ModelOut[]> {
   const params = new URLSearchParams();
   if (filters.capability) {
@@ -55,26 +34,6 @@ export async function listModels(filters: ModelFilters = {}): Promise<ModelOut[]
   const url = queryString
     ? `${API_BASE_URL}/v1/models?${queryString}`
     : `${API_BASE_URL}/v1/models`;
-
   const res = await fetch(url);
   return handleResponse<ModelOut[]>(res);
-}
-
-// Generate text from the backend
-export async function generateText(args: {
-  provider: string;
-  model: string;
-  prompt: string;
-}): Promise<{
-  content: string;
-  provider: string;
-  model: string;
-  metadata: Record<string, unknown>;
-}> {
-  const res = await fetch(`${API_BASE_URL}/v1/text/generate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(args),
-  });
-  return handleResponse(res);
 }

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -1,0 +1,16 @@
+import { API_BASE_URL, handleResponse } from './base';
+import type { ImageGenerateResponse } from '../types/api';
+
+export async function generateImages(args: {
+  provider: string;
+  model?: string;
+  prompt: string;
+  options?: Record<string, unknown>;
+}): Promise<ImageGenerateResponse> {
+  const res = await fetch(`${API_BASE_URL}/v1/images/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args),
+  });
+  return handleResponse(res);
+}

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,0 +1,19 @@
+import { API_BASE_URL, handleResponse } from './base';
+
+export async function generateText(args: {
+  provider: string;
+  model: string;
+  prompt: string;
+}): Promise<{
+  content: string;
+  provider: string;
+  model: string;
+  metadata: Record<string, unknown>;
+}> {
+  const res = await fetch(`${API_BASE_URL}/v1/text/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args),
+  });
+  return handleResponse(res);
+}

--- a/src/services/video.ts
+++ b/src/services/video.ts
@@ -1,0 +1,18 @@
+// TODO: Define the video generation API contract when backend is ready
+// Expected endpoint (subject to change): POST /v1/videos/generate
+
+export type VideoGenerateArgs = {
+  provider: string;
+  model?: string;
+  prompt: string;
+  options?: Record<string, unknown>;
+};
+
+// Placeholder response type until API is defined
+export type VideoGenerateResponse = unknown;
+
+export async function generateVideo(args: VideoGenerateArgs): Promise<VideoGenerateResponse> {
+  // keep args "used" to satisfy linting until implemented
+  void args;
+  throw new Error('Video generation API not implemented yet');
+}

--- a/src/stores/exec.ts
+++ b/src/stores/exec.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ExecState {
+  isGenerating: boolean;
+  setIsGenerating: (v: boolean) => void;
+}
+
+export const useExecStore = create<ExecState>((set) => ({
+  isGenerating: false,
+  setIsGenerating: (v: boolean) => set({ isGenerating: v }),
+}));

--- a/src/stores/thread/index.ts
+++ b/src/stores/thread/index.ts
@@ -1,0 +1,3 @@
+export * from './store';
+export * from './selectors';
+export * from '../../domain/thread';

--- a/src/stores/thread/selectors.ts
+++ b/src/stores/thread/selectors.ts
@@ -1,0 +1,25 @@
+import type { ImagePart, ThreadItem, VideoPart } from '../../domain/thread';
+
+export function selectAllImages(items: ThreadItem[]): ImagePart[] {
+  const acc: ImagePart[] = [];
+  for (const it of items) {
+    for (const p of it.parts) {
+      if (p.kind === 'image') {
+        acc.push(p as ImagePart);
+      }
+    }
+  }
+  return acc;
+}
+
+export function selectAllVideos(items: ThreadItem[]): VideoPart[] {
+  const acc: VideoPart[] = [];
+  for (const it of items) {
+    for (const p of it.parts) {
+      if (p.kind === 'video') {
+        acc.push(p as VideoPart);
+      }
+    }
+  }
+  return acc;
+}

--- a/src/stores/thread/store.ts
+++ b/src/stores/thread/store.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+import { generateId } from '../../lib/id';
+import type { CapabilityId } from '../../lib/store/selections';
+import type {
+  ContentPart,
+  ImagePart,
+  Role,
+  TextPart,
+  ThreadItem,
+  ThreadItemInput,
+  VideoPart,
+} from '../../domain/thread';
+
+export interface ThreadState {
+  items: ThreadItem[];
+  addItem: (item: ThreadItemInput) => void;
+  addText: (
+    content: string,
+    params: { role: Role; capability: CapabilityId; provider: string; model: string },
+  ) => void;
+  addImages: (
+    images: Array<Omit<ImagePart, 'kind'>>,
+    params: { role: Role; capability: CapabilityId; provider: string; model: string },
+  ) => void;
+  addVideos: (
+    videos: Array<Omit<VideoPart, 'kind'>>,
+    params: { role: Role; capability: CapabilityId; provider: string; model: string },
+  ) => void;
+  clear: () => void;
+}
+
+export const useThreadStore = create<ThreadState>((set) => ({
+  items: [],
+  addItem: (item) => {
+    const now = Date.now();
+    const finalItem: ThreadItem = {
+      id: item.id || generateId(),
+      createdAt: item.createdAt || now,
+      ...item,
+    } as ThreadItem;
+    set((state) => ({ items: [...state.items, finalItem] }));
+  },
+  addText: (content, params) => {
+    const part: TextPart = { kind: 'text', content };
+    set((state) => ({
+      items: [
+        ...state.items,
+        {
+          id: generateId(),
+          createdAt: Date.now(),
+          parts: [part as ContentPart],
+          role: params.role,
+          capability: params.capability,
+          provider: params.provider,
+          model: params.model,
+        },
+      ],
+    }));
+  },
+  addImages: (images, params) => {
+    const parts: ImagePart[] = images.map((img) => ({ kind: 'image', ...img }));
+    set((state) => ({
+      items: [
+        ...state.items,
+        {
+          id: generateId(),
+          createdAt: Date.now(),
+          parts,
+          role: params.role,
+          capability: params.capability,
+          provider: params.provider,
+          model: params.model,
+        },
+      ],
+    }));
+  },
+  addVideos: (videos, params) => {
+    const parts: VideoPart[] = videos.map((v) => ({ kind: 'video', ...v }));
+    set((state) => ({
+      items: [
+        ...state.items,
+        {
+          id: generateId(),
+          createdAt: Date.now(),
+          parts,
+          role: params.role,
+          capability: params.capability,
+          provider: params.provider,
+          model: params.model,
+        },
+      ],
+    }));
+  },
+  clear: () => set({ items: [] }),
+}));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -34,3 +34,14 @@ export interface ModelFilters {
   capability?: string;
   provider?: string;
 }
+
+// Image generation response
+export interface ImageArtifactOut {
+  data?: string | null;
+  path?: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface ImageGenerateResponse {
+  images: ImageArtifactOut[];
+}

--- a/ui-refacto.md
+++ b/ui-refacto.md
@@ -1,0 +1,379 @@
+## UI Refactor Proposal — celeste-react
+
+### Goals
+
+- **Keep Input independent of capability**: the same input bar UX for text, image, and video
+- **Separate concerns**: input/view logic vs capability execution vs API
+- **One place to decide how to execute** based on capability (no scattered branching)
+- **Consistent state model**: text thread, image gallery, video gallery managed predictably
+- **Predictable discovery**: capability → filtered providers/models is a read-only concern
+
+### Current Issues (What’s wrong now)
+
+- **Capability branching inside `useChat`**: `useChat` calls both text and image APIs. This couples text state (messages) with non-text flows, and forces the chat hook to know about other capabilities.
+- **Conditional rendering in `App.tsx` hides content**: Greeting vanishes when switching to image/video, revealing that “view state” is tied to text-only logic rather than the selected capability.
+- **`ChatInput` has mixed responsibilities**: it’s a capability selector, provider selector, model selector, and a text input; but its submit handler semantics are text-oriented. It should be a generic input bar that simply emits the prompt to a controller.
+- **Duplicated/fragmented types**: `ModelOut` appears both in `hooks/useModels.ts` and `types/api.ts` with slightly different shapes. This is brittle and confusing.
+- **Discovery vs execution mixed across layers**: `useChat` infers provider by fetching all models when none is set. Provider/model validation belongs outside the text-only hook.
+- **Environment variable**: Standardize on `VITE_API_BASE_URL` across code and docs.
+
+### Design Principles
+
+- **Single responsibility** per module:
+  - **InputBar**: capture prompt and user choices, never decides execution
+  - **Controllers**: map a prompt to an execution for the current capability
+  - **Services**: call backend endpoints
+  - **Stores**: hold UI state and results, one store per result domain
+- **Data flows one way** from input → controller → service → stores → views
+- **Capability is a runtime parameter**, not a compile-time branching across the app
+
+### Proposed Architecture
+
+#### Directory Structure
+
+```
+src/
+  domain/
+    capability.ts         # CapabilityId, result unions
+    types.ts              # Shared UI/domain types (e.g., TextMessage)
+  services/
+    text.ts               # generateText
+    images.ts             # generateImages
+    video.ts              # generateVideo (future)
+  controllers/
+    textController.ts     # useTextController
+    imageController.ts    # useImageController
+    videoController.ts    # useVideoController
+    interaction.ts        # useInteraction (selects correct controller based on capability)
+  stores/
+    selections.ts         # capability/provider/model/streaming (existing)
+    thread/
+      store.ts            # mixed-content conversation store (turns)
+      selectors.ts        # derived selectors (e.g., all images/videos)
+  lib/queries/
+    discovery.ts          # capabilities/providers/models (existing)
+  components/
+    input/
+      InputBar.tsx        # presentational input (rename from ChatInput)
+    results/
+      ResultSurface.tsx   # renders Greeting or the conversation thread
+      ThreadItemView.tsx  # renders one turn with all its parts
+      parts/
+        TextPart.tsx      # presentational text renderer
+        ImagePart.tsx     # presentational image renderer
+        VideoPart.tsx     # presentational video renderer
+    chat/
+      MessagesList.tsx    # remains presentational (no hook types import)
+      Greeting.tsx
+```
+
+#### Domain Types
+
+```ts
+// domain/capability.ts
+export type CapabilityId = 'text' | 'image' | 'video';
+
+export type TextResult = { kind: 'text'; message: string; metadata?: Record<string, unknown> };
+export type ImageResult = {
+  kind: 'image';
+  items: Array<{ dataUrl?: string; path?: string; metadata?: Record<string, unknown> }>;
+};
+export type VideoResult = {
+  kind: 'video';
+  items: Array<{ url?: string; path?: string; metadata?: Record<string, unknown> }>;
+};
+
+export type GenerationResult = TextResult | ImageResult | VideoResult;
+```
+
+```ts
+// domain/types.ts
+export type TextMessage = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  createdAt: number;
+};
+```
+
+#### Services (pure API layer)
+
+```ts
+// services/text.ts
+export async function generateText(args: { provider: string; model: string; prompt: string }) {
+  /* ... */
+}
+
+// services/images.ts
+export async function generateImages(args: {
+  provider: string;
+  model?: string;
+  prompt: string;
+  options?: Record<string, unknown>;
+}) {
+  /* ... */
+}
+
+// services/video.ts (future)
+export async function generateVideo(args: {
+  provider: string;
+  model?: string;
+  prompt: string;
+  options?: Record<string, unknown>;
+}) {
+  /* ... */
+}
+```
+
+#### Controllers
+
+Each controller performs one capability flow and appends turns to the unified thread:
+
+- Text: add user text turn → call `generateText` → add assistant text turn
+- Image: add user prompt turn → call `generateImages` → add assistant image parts turn
+- Video: same pattern when API is available
+
+Example (text):
+
+```ts
+// controllers/textController.ts
+import { useCallback, useState } from 'react';
+import { useSelectionsStore } from '../lib/store/selections';
+import { useThreadStore } from '../stores/thread';
+import { generateText } from '../services/text';
+
+export function useTextController() {
+  const provider = useSelectionsStore((s) => s.provider) || '';
+  const model = useSelectionsStore((s) => s.model) || '';
+  const addItem = useThreadStore((s) => s.addItem);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const execute = useCallback(
+    async (prompt: string) => {
+      if (!provider || !model) return;
+      addItem({
+        role: 'user',
+        capability: 'text',
+        provider,
+        model,
+        parts: [{ kind: 'text', content: prompt }],
+      });
+      setIsGenerating(true);
+      try {
+        const res = await generateText({ provider, model, prompt });
+        addItem({
+          role: 'assistant',
+          capability: 'text',
+          provider,
+          model,
+          parts: [{ kind: 'text', content: String(res?.content ?? '') }],
+        });
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [provider, model, addItem],
+  );
+
+  return { execute, isGenerating };
+}
+```
+
+```ts
+// controllers/interaction.ts
+export function useInteraction() {
+  const capability = useSelectionsStore((s) => s.capability);
+  const text = useTextController();
+  const image = useImageController();
+  const video = useVideoController();
+  const isGenerating = text.isGenerating || image.isGenerating || video.isGenerating;
+  const submit = useCallback(
+    (prompt: string) => {
+      if (capability === 'text') return text.execute(prompt);
+      if (capability === 'image') return image.execute(prompt);
+      return video.execute(prompt);
+    },
+    [capability, text.execute, image.execute, video.execute],
+  );
+  return { submit, isGenerating };
+}
+```
+
+#### Stores
+
+- **`useSelectionsStore`**: keep as-is (capability/provider/model/streaming)
+- **`useTextThreadStore`**: manages `TextMessage[]`
+- **`useImageGalleryStore`**: manages an array of image results (and maybe history across prompts)
+- **`useVideoGalleryStore`**: analogous to images
+
+These are independent, so switching capability doesn’t erase state. Greeting visibility becomes: “show greeting if the current capability store has no results/messages”.
+
+#### Components
+
+- **`InputBar`** (rename of `ChatInput`):
+  - Props: `value`, `onChange`, `onSubmit`, `providers`, `models`, `selectedProvider`, `selectedModel`, `selectedCapability`, `onSelectCapability`
+  - No capability-specific branching; placeholder text can optionally adapt, but behavior stays the same
+
+- **`ResultSurface`**:
+  - Reads selected capability
+  - For `text`: render `TextThread` with `useTextThreadStore`
+  - For `image`: render `ImageGallery` with `useImageGalleryStore`
+  - For `video`: render `VideoGallery` with `useVideoGalleryStore`
+  - If the chosen store is empty: render `Greeting`
+
+- **`App.tsx`**:
+  - Top-level discovery and selection
+  - Renders `ResultSurface`
+  - Renders `InputBar` wired to `useInteraction()`
+
+### Validation Rules and UX
+
+- Require `provider` and `model` before executing. If missing, surface a toast/banner or inline hint; don’t let controllers infer provider by fetching all models.
+- Keep the input visible regardless of capability. Only results surface changes.
+- Persist per-capability results in their own stores so users can switch back and forth without losing context.
+
+### API/Types Cleanup
+
+- **Unify types**: export and consume `ModelOut` from a single source (`types/api.ts`), delete the duplicate in `hooks/useModels.ts`.
+- **Env var name**: standardized on `VITE_API_BASE_URL` across code and docs.
+- **Binary handling**: for images, the backend should return `data` as base64 with media type (`data:image/png;base64,...`) to avoid latin1 encoding quirks. If that’s not possible, the client should convert bytes to base64 safely via `Blob`/`FileReader`.
+
+### Step-by-step Refactor Plan
+
+1. **Introduce domain types** (`domain/`) and result unions
+2. **Split services** into `services/text.ts`, `services/images.ts`, `services/video.ts`
+3. **Create stores**: `textThread`, `imageGallery`, `videoGallery`
+4. **Extract controllers** for each capability
+5. **Add `useInteraction`** that selects controller by capability
+6. **Rename `ChatInput` → `InputBar`** and change props to `onSubmit(prompt: string)`; wire to `useInteraction().submit`
+7. **Create `ResultSurface`** and make `App.tsx` render it unconditionally (no conditional greeting tied to text)
+8. **Remove capability branching** from `useChat`; delete/replace with `useTextController`
+9. **Unify `ModelOut`** type usage and fix env var naming
+10. **Delete dead/duplicate hooks** (old `useModels` if superseded by query hooks)
+
+### What This Fixes
+
+- Greeting visibility no longer depends on text-only state
+- Input remains the same across capabilities
+- Capability logic lives in a single, swappable controller layer
+- API calls are isolated and testable, stores are simple
+- Reduced duplication, clearer mental model
+
+### Optional Enhancements
+
+- **Result history** per capability with tabs (e.g., per prompt) for images/videos
+- **Background jobs** and polling for video generation
+- **Streaming text** integration via WebSocket for the text controller
+
+---
+
+This architecture keeps UX consistent (one input, one surface) while enforcing clean boundaries between input, capability execution, and API details. It also makes adding new capabilities straightforward: implement a controller, a store, and a surface component, then register it with `useInteraction`.
+
+### Task Breakdown and Checklist
+
+#### Analysis (complete)
+
+- [x] Audit current coupling and UX issues
+- [x] Draft refactor architecture and plan in `ui-refacto.md`
+
+#### Foundation & Cleanup
+
+- [x] Standardize env var naming in code and docs (decided: `VITE_API_BASE_URL`)
+- [x] Unify `ModelOut` type in `src/types/api.ts`; remove duplicate from `hooks/useModels.ts`
+- [x] Remove provider inference logic from any execution path (validation happens before submit)
+
+#### Services Layer
+
+- [x] Create `src/services/text.ts` and move `generateText` there
+- [x] Create `src/services/images.ts` and move `generateImages` there
+- [x] Create `src/services/video.ts` (stub with TODO for API contract)
+- [x] Split into `services/base.ts` (config/helpers) and `services/discovery.ts` (health/capabilities/providers/models)
+- [x] Remove broad `services/api.ts` usage; update imports across the app
+
+#### Stores
+
+- [x] Create `src/stores/thread` with a single mixed-content conversation
+  - [x] `items: ThreadItem[]`
+  - [x] Action: `addItem({ role, capability, provider, model, parts })`, plus `clear()`
+  - [x] Optional convenience wrappers: `addText(content, role)`, `addImages(images, role)`, `addVideos(videos, role)`
+  - [x] Selectors: `selectAllImages(items)`, `selectAllVideos(items)` for gallery views
+  - [ ] Optional: persist to localStorage
+
+Store breakdown (separation of concerns):
+
+- `src/domain/thread.ts`: Role, ContentPart, ThreadItem, ThreadItemInput (types only)
+- `src/lib/id.ts`: `generateId()` utility
+- `src/stores/thread/store.ts`: Zustand store and actions (`addItem`, `addText`, `addImages`, `addVideos`, `clear`)
+- `src/stores/thread/selectors.ts`: derived selectors (`selectAllImages`, `selectAllVideos`)
+- `src/stores/thread/index.ts`: barrel re-exports (store, selectors, and types)
+
+#### Controllers
+
+- [x] Implement `src/controllers/textController.ts` (`useTextController`) to call text service and append assistant text to the thread
+- [x] Implement `src/controllers/imageController.ts` (`useImageController`) to call image service and append assistant images to the thread
+- [x] Implement `src/controllers/videoController.ts` (`useVideoController`) to call video service and append assistant videos to the thread
+- [x] Add `src/controllers/index.ts` barrel to export all controllers
+
+#### Interaction Layer
+
+- [x] Implement `src/controllers/interaction.ts` with `useInteraction` exposing `{ submit(prompt), isGenerating }`
+- [x] Ensure only one controller executes based on `useSelectionsStore().capability`
+
+#### Components (Views)
+
+- [x] Rename `src/components/chat/ChatInput.tsx` to `src/components/input/InputBar.tsx`
+- [x] Change props to `onSend(prompt: string)` and delegate provider/model/capability changes via props
+- [x] Create `src/components/results/ResultSurface.tsx` that renders Greeting when thread empty or the conversation when not
+- [x] Create `src/components/results/ThreadItemView.tsx` to render a single ThreadItem (iterate its parts)
+- [ ] Create presentational parts:
+  - [x] `src/components/results/parts/TextPart.tsx`
+  - [x] `src/components/results/parts/ImagePart.tsx`
+  - [x] `src/components/results/parts/VideoPart.tsx`
+- [x] Make input placeholder adapt to capability (optional polish)
+
+Text rendering:
+
+- [x] Render text parts as Markdown (.md) using `react-markdown` with `remark-gfm` for proper formatting
+
+Styling polish (planned):
+
+- [x] Style `ResultSurface` and `ThreadItemView` with CSS modules to match previous chat layout
+- [x] Use `useInteraction().isGenerating` to show rotating star loader (reuse spinner from `MessagesList`)
+- [x] Align turns left/right and show avatars based on role (user vs assistant)
+- [x] Ensure spacing and add bottom spacer so `InputBar` doesn’t overlap content
+- [ ] Reuse tokens from `MessagesList.module.css` where sensible
+
+#### App Wiring
+
+- [x] Update `src/App.tsx` to render `ResultSurface` and `InputBar` unconditionally (no conditional greeting tied to text)
+- [x] Wire `InputBar.onSend` to `useInteraction().submit`
+- [x] Keep discovery-driven provider/model lists; remove any execution logic from App
+- [x] Remove usage of `hooks/useChat.ts` and delete the file after migration
+
+#### Discovery / Queries
+
+- [x] Choose single source for models: prefer `lib/queries/discovery.ts`; remove `hooks/useModels.ts` if redundant
+- [x] Keep a single `capabilityFilterMap` and reuse it
+
+#### Backend Integration
+
+- [x] Include `images` router in API (already added)
+- [ ] Align image response format (prefer `data:image/*;base64,....`) or add robust client-side conversion
+- [ ] Define video generation endpoint contract (method, payload, response), implement later
+
+#### UX & Validation
+
+- [ ] Prevent submit until provider/model selected; show inline hint near selectors
+- [ ] Preserve per-capability results when switching (stores independent of view)
+- [ ] Add keyboard shortcut support (Enter to submit; Shift+Enter to newline if needed later)
+
+#### Testing & CI
+
+- [ ] Unit test controllers (mock services, assert store updates)
+- [ ] E2E smoke tests for text/image flows
+- [ ] Ensure lints and type checks pass
+
+#### Documentation
+
+- [ ] Update `README.md` to reflect InputBar and ResultSurface
+- [ ] Link this architecture document from the repo root (ADR/Docs section)


### PR DESCRIPTION
Summary\n- Unified mixed-content conversation thread (stores/thread)\n- Added controllers (text/image/video) and useInteraction() for capability routing\n- Split services: base/discovery/text/images/video; removed legacy api.ts\n- InputBar replaces ChatInput; ResultSurface + ThreadItemView render thread\n- Markdown rendering for text; spinner tied to global generating state\n- Centralized capability map; removed legacy hooks (useChat/useModels)\n\nRationale\n- Separation of concerns: services, controllers, stores, views\n- One thread preserves context across capability switches\n- Cleaner App: discovery-only; execution via interaction layer\n\nFollow-ups\n- Styling polish (CSS modules already added but more tuning)\n- Video backend contract; image data URL consistency\n- Persistence of thread store (optional)