### PR TITLE
Memoize conversation load handling

### DIFF
--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { repository } from "../infrastructure/repository";
 import { Conversation } from "../domain/entities/Conversation";
 import { useThreadStore } from "../stores/thread.store";
@@ -7,30 +7,36 @@ export function useConversation() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const { conversationId, setConversationId } = useThreadStore();
 
-  const loadConversations = async () => {
+  const loadConversations = useCallback(async () => {
     const loaded = await repository.loadConversations();
     setConversations(loaded);
-  };
+  }, []);
 
-  const createConversation = async (title: string) => {
-    const conversation = Conversation.create(title);
-    await repository.saveConversation(conversation);
-    setConversationId(conversation.getId());
-    await loadConversations();
-    return conversation;
-  };
+  const createConversation = useCallback(
+    async (title: string) => {
+      const conversation = Conversation.create(title);
+      await repository.saveConversation(conversation);
+      setConversationId(conversation.getId());
+      await loadConversations();
+      return conversation;
+    },
+    [loadConversations, setConversationId]
+  );
 
-  const deleteConversation = async (id: string) => {
-    await repository.deleteConversation(id);
-    if (conversationId === id) {
-      setConversationId("");
-    }
-    await loadConversations();
-  };
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      await repository.deleteConversation(id);
+      if (conversationId === id) {
+        setConversationId("");
+      }
+      await loadConversations();
+    },
+    [conversationId, loadConversations, setConversationId]
+  );
 
   useEffect(() => {
     loadConversations();
-  }, []);
+  }, [loadConversations]);
 
   return {
     conversations,

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -26,12 +26,13 @@ export function useConversation() {
   const deleteConversation = useCallback(
     async (id: string) => {
       await repository.deleteConversation(id);
-      if (conversationId === id) {
+      const { conversationId: currentConversationId } = useThreadStore.getState();
+      if (currentConversationId === id) {
         setConversationId("");
       }
       await loadConversations();
     },
-    [conversationId, loadConversations, setConversationId]
+    [loadConversations, setConversationId]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- memoize the conversation loading helper with `useCallback`
- memoize conversation creation/deletion actions to reuse the shared loader
- update the effect dependency array to respond to loader changes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c9114d9468832c846cd5b7d803fae9