### PR TITLE
Handle null conversation IDs on deletion

### DIFF
--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -28,7 +28,7 @@ export function useConversation() {
       await repository.deleteConversation(id);
       const { conversationId: currentConversationId } = useThreadStore.getState();
       if (currentConversationId === id) {
-        setConversationId("");
+        setConversationId(null);
       }
       await loadConversations();
     },

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -5,7 +5,7 @@ interface ThreadState {
   thread: Thread | null;
   conversationId: string | null;
   setThread: (thread: Thread) => void;
-  setConversationId: (id: string) => void;
+  setConversationId: (id: string | null) => void;
   clear: () => void;
 }
 


### PR DESCRIPTION
## Summary
- clear the selected conversation ID to null when a conversation is deleted
- allow the thread store setter to accept null IDs when clearing state

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68c9169f6698832ca3aa71d01dcc4ff0