### PR TITLE
Ensure conversations payload uses snake case timestamps

### DIFF
--- a/src/infrastructure/repository.ts
+++ b/src/infrastructure/repository.ts
@@ -69,13 +69,16 @@ export const repository = {
   },
 
   async saveConversation(conversation: Conversation): Promise<void> {
-    const data = conversation.toJSON();
     const user = await supabase.auth.getUser();
     const userId = user.data.user?.id || "";
 
     await supabase.from("conversations")
       .upsert({
-        ...data,
+        id: conversation.getId(),
+        title: conversation.getTitle(),
+        created_at: conversation.getCreatedAt().toISOString(),
+        updated_at: conversation.getUpdatedAt().toISOString(),
+        metadata: conversation.getMetadata(),
         user_id: userId
       });
   },


### PR DESCRIPTION
## Summary
- replace the conversation JSON spread with explicit field mapping
- send created_at and updated_at in snake_case along with metadata when upserting conversations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91e1e9c4c832cbd3d0746fe130f2d