### PR TITLE
Ensure thread state resets after persistence

### DIFF
--- a/src/hooks/useThread.ts
+++ b/src/hooks/useThread.ts
@@ -115,6 +115,7 @@ export function useThread() {
 
     if (activeConversationId) {
       await repository.saveThread(currentThread, activeConversationId);
+      setThread(currentThread.clone());
     }
   };
 


### PR DESCRIPTION
## Summary
- update sendMessage to refresh the stored thread after saving so state reflects markClean
- ensure subsequent thread saves operate on a clean copy and avoid re-inserting existing messages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91e24fe58832c899941e3aa55c012