### PR TITLE
Add Docker configuration for static build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,10 @@ npm-cache
 bower_components
 dist
 .git
+.env*
+!.env.example
+*.log
+.DS_Store
+coverage
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,32 @@ WORKDIR /app
 # Enable corepack to make pnpm available
 RUN corepack enable
 
-# Install dependencies
+# Copy dependency manifests and install dependencies (including dev deps for the build)
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+
+ARG VITE_API_BASE_URL
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ENV VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
+ENV VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
+
+RUN pnpm install --frozen-lockfile --production=false
 
 # Copy the rest of the source and build
 COPY . .
 RUN pnpm build
 
+# Prune the pnpm store to reduce layer size
+RUN pnpm store prune
+
 # Runtime stage using nginx to serve static assets
 FROM nginx:alpine AS runner
+
+ENV NODE_ENV=production
+
+# Replace the default nginx configuration with our SPA-friendly config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -142,6 +142,29 @@ pnpm build
 
 Builds the app to the `dist` folder, optimized for production.
 
+### Docker
+
+Build and run the production image locally:
+
+```bash
+# Build image
+docker build -t celeste-react .
+
+# Run container
+docker run -p 8080:80 celeste-react
+```
+
+> [!TIP]
+> Provide build-time configuration by passing `--build-arg` values, for example:
+>
+> ```bash
+> docker build \
+>   --build-arg VITE_API_BASE_URL=https://api.example.com \
+>   --build-arg VITE_SUPABASE_URL=https://your-project.supabase.co \
+>   --build-arg VITE_SUPABASE_ANON_KEY=super-secret \
+>   -t celeste-react .
+> ```
+
 ### Run Tests
 
 ```bash

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: wss:; font-src 'self' data: https:; img-src 'self' data: blob: https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https:; object-src 'none'; frame-ancestors 'none';" always;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the app with pnpm and serves the built assets via nginx
- ignore node modules and other build caches in the Docker build context

## Testing
- docker build -t celeste-react . *(fails: `docker` not available in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c9568ab188832c9db115cfbb259626